### PR TITLE
Add profile page

### DIFF
--- a/src/app/profile/page.module.scss
+++ b/src/app/profile/page.module.scss
@@ -1,0 +1,47 @@
+.main {
+  padding: 2rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-top: 1rem;
+}
+
+.section {
+  background: var(--color-card-bg);
+  padding: 1.5rem;
+  border-radius: var(--border-radius);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+
+  label {
+    margin-bottom: 0.25rem;
+    color: var(--color-text-muted);
+  }
+
+  input {
+    padding: 0.5rem;
+    border-radius: 4px;
+    border: 1px solid #444;
+    background: #2a2a2a;
+    color: #fff;
+  }
+}
+
+.saveButton {
+  align-self: flex-start;
+  padding: 0.5rem 1.25rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from 'react';
+import Header from '@/components/Header';
+import styles from './page.module.scss';
+
+interface Address {
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
+}
+
+interface Banking {
+  bankName: string;
+  accountNumber: string;
+  routingNumber: string;
+}
+
+export default function ProfilePage() {
+  const [address, setAddress] = useState<Address>({
+    street: '',
+    city: '',
+    state: '',
+    zip: '',
+  });
+
+  const [banking, setBanking] = useState<Banking>({
+    bankName: '',
+    accountNumber: '',
+    routingNumber: '',
+  });
+
+  const handleAddressChange = (field: keyof Address) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setAddress({ ...address, [field]: e.target.value });
+  };
+
+  const handleBankChange = (field: keyof Banking) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setBanking({ ...banking, [field]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Placeholder for saving logic
+    alert('Profile saved');
+  };
+
+  return (
+    <>
+      <Header />
+      <main className={styles.main}>
+        <h1>User Profile</h1>
+        <form className={styles.form} onSubmit={handleSubmit}>
+          <section className={styles.section}>
+            <h2>Address</h2>
+            <div className={styles.field}> 
+              <label htmlFor="street">Street</label>
+              <input id="street" type="text" value={address.street} onChange={handleAddressChange('street')} />
+            </div>
+            <div className={styles.field}> 
+              <label htmlFor="city">City</label>
+              <input id="city" type="text" value={address.city} onChange={handleAddressChange('city')} />
+            </div>
+            <div className={styles.field}> 
+              <label htmlFor="state">State</label>
+              <input id="state" type="text" value={address.state} onChange={handleAddressChange('state')} />
+            </div>
+            <div className={styles.field}> 
+              <label htmlFor="zip">ZIP</label>
+              <input id="zip" type="text" value={address.zip} onChange={handleAddressChange('zip')} />
+            </div>
+          </section>
+
+          <section className={styles.section}>
+            <h2>Banking Information</h2>
+            <div className={styles.field}> 
+              <label htmlFor="bankName">Bank Name</label>
+              <input id="bankName" type="text" value={banking.bankName} onChange={handleBankChange('bankName')} />
+            </div>
+            <div className={styles.field}> 
+              <label htmlFor="accountNumber">Account Number</label>
+              <input id="accountNumber" type="text" value={banking.accountNumber} onChange={handleBankChange('accountNumber')} />
+            </div>
+            <div className={styles.field}> 
+              <label htmlFor="routingNumber">Routing Number</label>
+              <input id="routingNumber" type="text" value={banking.routingNumber} onChange={handleBankChange('routingNumber')} />
+            </div>
+          </section>
+
+          <button className={styles.saveButton} type="submit">Save</button>
+        </form>
+      </main>
+    </>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,7 +25,7 @@ export default function Header() {
             <Link href="#">Tools</Link>
             <Link href="#">Documents</Link>
             <Link href="#">Requests</Link>
-            <Link href="#">Profile</Link>
+            <Link href="/profile">Profile</Link>
           </nav>
           {/* Show user button when signed in */}
           <SignedIn>


### PR DESCRIPTION
## Summary
- create `/profile` page with a form for address and banking information
- add styling module for the profile page
- link "Profile" in the header navigation to the new page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876d9b9bbd4832982a5454ae992bf02