### PR TITLE
Connect dashboard to API

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+import dashboardData from '@/data/dashboardData';
+
+export async function GET() {
+  return NextResponse.json(dashboardData);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,9 @@
 import Image from 'next/image';
 import Header from '@/components/Header';
 import StatCard from '@/components/StatCard';
-import dashboardData from '@/data/dashboardData';
 import styles from './page.module.scss';
 import SectionHeader from '@/components/SectionHeader';
+import { useEffect, useState } from 'react';
 
 // Chart components (client-side rendered)
 import BalanceFlowChart from '@/components/client/BalanceFlowChartClient';
@@ -13,13 +13,36 @@ import ReturnComboChart from '@/components/client/ReturnComboClient';
 
 import { SignedIn, SignedOut, SignIn } from "@clerk/nextjs";
 
+type DashboardData = {
+  welcome: { line1: string; line2: string };
+  stats: { label: string; value: string }[];
+  historical: { label: string; value: string }[];
+};
+
 export default function Home() {
-  const { welcome, stats, historical } = dashboardData;
+  const [data, setData] = useState<DashboardData | null>(null);
+
+  useEffect(() => {
+    fetch('/api/dashboard')
+      .then((res) => res.json())
+      .then((d: DashboardData) => setData(d))
+      .catch(() => setData(null));
+  }, []);
+
+  const { welcome, stats, historical } = data ?? {
+    welcome: { line1: '', line2: '' },
+    stats: [],
+    historical: [],
+  };
 
   return (
     <>
       {/* Show dashboard only when the user is signed in */}
       <SignedIn>
+        {!data ? (
+          <p>Loading...</p>
+        ) : (
+        <>
         <Header />
         <main className={styles.main}>
           <section className={styles.welcome}>
@@ -65,6 +88,8 @@ export default function Home() {
             </div>
           </section>
         </main>
+        </>
+      )}
       </SignedIn>
 
       {/* Show sign-in form when the user is signed out */}


### PR DESCRIPTION
## Summary
- create `/api/dashboard` route to serve mock JSON data
- fetch dashboard data from the new API in the home page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876d91dcc50832995bda6784b38d87b